### PR TITLE
Create the java sources in tmp directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <version>3.4.2</version>
@@ -123,6 +117,13 @@
 				  <artifactId>commons-io</artifactId>
 				  <version>2.11.0</version>
 		  </dependency>
+
+		  <dependency>
+				  <groupId>junit</groupId>
+				  <artifactId>junit</artifactId>
+				  <version>4.13.2</version>
+				  <scope>test</scope>
+		  </dependency>
   </dependencies>
 
   <build>
@@ -136,8 +137,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <source>6</source>
-          <target>6</target>
+          <source>7</source>
+          <target>7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
   <groupId>com.signavio</groupId>
   <artifactId>gettext-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.2.7</version>
+  <version>1.2.8-SNAPSHOT</version>
   <name>Maven Gettext Plugin</name>
   <description>Generate messages templates and deploy messages bundles</description>
   <properties>
-    <gitUrl>effektif/gettext-maven-plugin</gitUrl>
+    <gitUrl>signavio/gettext-maven-plugin</gitUrl>
   </properties>
   <licenses>
     <license>
@@ -59,72 +59,90 @@
     <url>https://github.com/${gitUrl}</url>
   </scm>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>signavio-plugins-snapshots</id>
-      <name>signavio-snapshots</name>
-      <url>https://signavio.artifactoryonline.com/signavio/plugins-snapshot-local</url>
-    </snapshotRepository>
+  <repositories>
     <repository>
-      <id>signavio-plugins-releases</id>
-      <name>signavio-releases</name>
-      <url>https://signavio.artifactoryonline.com/signavio/plugins-release-local</url>
+      <id>signavio-releases</id>
+      <url>https://signavio.jfrog.io/signavio/libs-release</url>
     </repository>
-    <site>
-      <id>gh-pages</id>
-      <name>GitHub Pages</name>
-      <url>git:ssh://git@github.com/${gitUrl}.git?gh-pages#</url>
-    </site>
-  </distributionManagement>
+    <repository>
+      <id>signavio-snapshots</id>
+      <url>https://signavio.jfrog.io/signavio/libs-snapshot</url>
+    </repository>
+    <repository>
+      <id>jcenter</id>
+      <url>https://jcenter.bintray.com/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>signavio-plugins-releases</id>
+      <url>https://signavio.jfrog.io/signavio/plugins-release</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>jcenter</id>
+      <url>https://jcenter.bintray.com/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.3.1</version>
+      <version>3.8.5</version>
     </dependency>
     <!-- dependencies to annotations -->
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.4</version>
+      <version>3.6.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.22</version>
+      <version>3.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>
-      <version>3.0</version>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
-      <version>2.3</version>
+      <version>3.1.0</version>
     </dependency>
+		  <dependency>
+				  <groupId>commons-io</groupId>
+				  <artifactId>commons-io</artifactId>
+				  <version>2.11.0</version>
+		  </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.6.4</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.10.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>6</source>
+          <target>6</target>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.12.0</version>
         <dependencies>
           <dependency>
             <groupId>net.trajano.wagon</groupId>
@@ -140,12 +158,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.8.6</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changes-plugin</artifactId>
-        <version>2.9</version>
+        <version>2.12.1</version>
         <reportSets>
           <reportSet>
             <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,19 @@
     <url>https://github.com/${gitUrl}</url>
   </scm>
 
+		<distributionManagement>
+				<repository>
+						<id>central</id>
+						<name>signavio-releases</name>
+						<url>https://signavio.jfrog.io/artifactory/plugins-release-local</url>
+				</repository>
+				<snapshotRepository>
+						<id>snapshots</id>
+						<name>signavio-snapshots</name>
+						<url>https://signavio.jfrog.io/artifactory/plugins-snapshot-local</url>
+				</snapshotRepository>
+		</distributionManagement>
+
   <repositories>
     <repository>
       <id>signavio-releases</id>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,9 @@
   <name>Maven Gettext Plugin</name>
   <description>Generate messages templates and deploy messages bundles</description>
   <properties>
-    <gitUrl>signavio/gettext-maven-plugin</gitUrl>
+		  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		  <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		  <gitUrl>signavio/gettext-maven-plugin</gitUrl>
   </properties>
   <licenses>
     <license>
@@ -102,6 +104,7 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.5</version>
+		    <scope>provided</scope>
     </dependency>
     <!-- dependencies to annotations -->
     <dependency>

--- a/src/main/java/org/xnap/commons/maven/gettext/DistMojo.java
+++ b/src/main/java/org/xnap/commons/maven/gettext/DistMojo.java
@@ -18,9 +18,7 @@ package org.xnap.commons.maven.gettext;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.*;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.LocaleUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.*;
@@ -36,14 +34,11 @@ import org.codehaus.plexus.util.cli.*;
 @Mojo(name = "dist", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class DistMojo extends AbstractGettextMojo {
 
-    private static Path TMP_DIR;
+    private static File tmpDir;
 
     public DistMojo() {
-        try {
-            TMP_DIR = Files.createTempDirectory("gettext-maven");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        tmpDir = new File(System.getProperty("java.io.tmpdir"), "gettext-maven-plugin");
+        tmpDir.mkdirs();
     }
 
     /**
@@ -92,7 +87,7 @@ public class DistMojo extends AbstractGettextMojo {
     protected boolean asSource;
 
     public void execute() throws MojoExecutionException {
-        final FileMover fileMover = new FileMover(getLog(), TMP_DIR.toFile(), targetBundle, outputDirectory);
+        final FileMover fileMover = new FileMover(getLog(), tmpDir, targetBundle, outputDirectory);
 
         outputDirectory.mkdirs();
 
@@ -137,7 +132,7 @@ public class DistMojo extends AbstractGettextMojo {
 
             if (asSource) {
                 try {
-                    fileMover.moveTmpFilesToOutputDirectory(outputFile);
+                    fileMover.moveTmpFileToOutputDirectory(outputFile);
                 } catch (IOException e) {
                     throw new MojoExecutionException(
                         "Unable to move files to outputDirectory: " + outputDirectory, e);
@@ -207,7 +202,7 @@ public class DistMojo extends AbstractGettextMojo {
             if (asSource) {
                 cl.createArg().setValue("--source");
                 cl.createArg().setValue("-d");
-                cl.createArg().setFile(TMP_DIR.toFile());
+                cl.createArg().setFile(tmpDir);
             } else {
                 cl.createArg().setValue("-d");
                 cl.createArg().setFile(outputDirectory);

--- a/src/main/java/org/xnap/commons/maven/gettext/FileMover.java
+++ b/src/main/java/org/xnap/commons/maven/gettext/FileMover.java
@@ -1,0 +1,44 @@
+package org.xnap.commons.maven.gettext;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.logging.Log;
+
+public class FileMover {
+
+    private final Log log;
+    private final File tmpDir;
+    private final String targetBundle;
+    private final File outputDirectory;
+
+    public FileMover(Log log, File tmpDir, String targetBundle, File outputDirectory) {
+        this.log = log;
+        this.tmpDir = tmpDir;
+        this.targetBundle = targetBundle;
+        this.outputDirectory = outputDirectory;
+    }
+
+    public void moveTmpFilesToOutputDirectory(File outputFile) throws IOException {
+        final String bundlePackage = targetBundle.substring(0, targetBundle.lastIndexOf("."));
+        log.debug("bundlePackage: " + bundlePackage);
+        final File bundleDir = Paths.get(tmpDir.getAbsolutePath(), bundlePackage.split("\\.")).toFile();
+        log.debug("bundleDir: " + bundleDir);
+        final File bundleFile = new File(bundleDir, getTargetFilename(outputFile));
+        log.debug("bundleFile: " + bundleFile);
+        final Path outDir = Paths.get(outputDirectory.getAbsolutePath(), bundlePackage.split("\\."));
+        final File destFile = new File(outDir.toFile(), getTargetFilename(outputFile));
+        log.debug("destFile: " + destFile);
+
+        log.info("Moving file '" + bundleFile + "' to '" + destFile + "'");
+        FileUtils.delete(destFile);
+        FileUtils.moveFile(bundleFile, destFile, StandardCopyOption.REPLACE_EXISTING);
+        FileUtils.cleanDirectory(tmpDir);
+    }
+
+    private static String getTargetFilename(File outputFile) {
+        return outputFile.getName().replace(".class", ".java");
+    }
+}

--- a/src/test/java/org/xnap/commons/maven/gettext/FileMoverTest.java
+++ b/src/test/java/org/xnap/commons/maven/gettext/FileMoverTest.java
@@ -1,0 +1,67 @@
+package org.xnap.commons.maven.gettext;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.codehaus.plexus.logging.Logger;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FileMoverTest {
+
+    @Rule
+    public final TemporaryFolder tmp = new TemporaryFolder();
+    private FileMover fileMover;
+    private File tmpDir;
+    private File output;
+
+    @Before
+    public void setUp() throws Exception {
+        tmpDir = tmp.newFolder("tmp");
+        final DefaultLog log = new DefaultLog(new ConsoleLogger(Logger.LEVEL_DEBUG, "console"));
+         output = tmp.newFolder("output");
+        fileMover = new FileMover(log,
+            tmpDir,
+            "com.my.bundle.Messages",
+            output);
+    }
+
+    @Test( expected = IOException.class)
+    public void shouldFailIfBundleSourceMissing() throws IOException {
+        // act
+        fileMover.moveTmpFileToOutputDirectory(new File("Messages_de_DE.class"));
+    }
+
+    @Test
+    public void shouldCleanTmpDirectory() throws IOException {
+        // arrange
+        final File bundleDir = new File(tmpDir, "com/my/bundle/");
+        bundleDir.mkdirs();
+        new File(bundleDir, "Messages_de_DE.java").createNewFile();
+
+        // act
+        fileMover.moveTmpFileToOutputDirectory(new File("Messages_de_DE.class"));
+
+        // assert
+        assertEquals(0, tmpDir.listFiles().length);
+    }
+
+    @Test
+    public void shouldMoveBundleFileToOutputDirectory() throws IOException {
+        // arrange
+        final File bundleDir = new File(tmpDir, "com/my/bundle/");
+        bundleDir.mkdirs();
+        new File(bundleDir, "Messages_de_DE.java").createNewFile();
+
+        // act
+        fileMover.moveTmpFileToOutputDirectory(new File("Messages_de_DE.class"));
+
+        // assert
+        assertTrue(new File(output, "com/my/bundle/Messages_de_DE.java").exists());
+    }
+}


### PR DESCRIPTION
- Fixes [SPG-759](https://jira.signavio.com/browse/SPG-759)

**What does this PR do?**
Call `msgfmt` to create the java sources in a temporary (and always empty) directory and then move the files to the `outputDirectory`.

**How to test it?**
1. Install the plugin locally with jdk8: `mvn clean install`
2. Use it in workflow-server: Replace `gettext-maven-plugin` version with `1.2.8-SNAPSHOT`
3. Run the plugin: `workflow-server$ mvn gettext:dist`

**Expected result**
```
workflow-server$ tree generated-sources/
generated-sources/
└── com
    └── signavio
        └── workflow
            └── i18n
                ├── Messages_de_DE.java
                ├── Messages_en.properties
                ├── Messages_en_US.java
                ├── Messages_es_ES.java
                ├── Messages_fr_FR.java
                └── Messages.properties
``` 

Extra test:
`mvn clean test -Dtest=com.effektif.product.test.jobs.LicenseExpirationReminderJobIntegrationTest`
And expect a successful run.